### PR TITLE
Bids preproc

### DIFF
--- a/BIDS/prisma_to_BIDS.py
+++ b/BIDS/prisma_to_BIDS.py
@@ -76,8 +76,8 @@ def _construct_base_filename(example_file, output_dir, data_type, run_flag=False
     return base_filename.format(**filename_kw), subj_dir
 
 
-def copy_func(data_dir, output_dir, epis, sbrefs, task_label, session_label=None, acq_label=None,
-              rec_label=None, echo_index=None):
+def copy_func(data_dir, output_dir, epis, sbrefs, task_label, PEdim='j', session_label=None,
+              acq_label=None, rec_label=None, echo_index=None):
     """copy functional data to BIDS format
 
     looks for both .nii and .nii.gz files
@@ -103,6 +103,11 @@ def copy_func(data_dir, output_dir, epis, sbrefs, task_label, session_label=None
     the subject directory already exists, session_label is required
 
     task_label: str, task label. str to identify the task, required by BIDS.
+
+    PEdim: Phase encoding dimension. BIDS expects direction to use i, j, and k, but FSL uses x, y,
+    and z. This function accepts both and will map between the two like so: x->i, y->j, z->k. They
+    should either be by themselves (e.g., 'j' or 'y') or have a dash afterwards to show it's
+    reversed (e.g., 'j-' or 'y-').
 
     session_label: str, session label, optional. if there is not subject directory in output_dir
     for this subject, then this is unnecessary. if there *is*, then a session_label is needed.
@@ -153,7 +158,14 @@ def copy_func(data_dir, output_dir, epis, sbrefs, task_label, session_label=None
             tr /= 1000
         elif t_units != 'sec':
             raise Exception("Don't know how to handle units %s for TR" % t_units)
-        bold_dict = {"TaskName": task_label, 'RepetitionTime': float(tr)}
+        possible_PEdims = ['x', 'y', 'z', 'i', 'j', 'k', 'x-', 'y-', 'z-', 'i-', 'j-', 'k-']
+        if PEdim not in possible_PEdims:
+            raise Exception("Don't know how to handle PEdim %s!" % PEdim)
+        phase_dir = {'x': 'i', 'y': 'j', 'z': 'k'}.get(PEdim[0], PEdim[0])
+        if len(PEdim) > 1:
+            phase_dir += '-'
+        bold_dict = {"TaskName": task_label, 'RepetitionTime': float(tr),
+                     'PhaseEncodingDirection': phase_dir}
         with open(os.path.join(subj_dir, epi_filename % (i+1, 'json')), 'w') as f:
             json.dump(bold_dict, f)
 
@@ -172,6 +184,10 @@ def copy_fmap(data_dir, output_dir, distortPE, distortrevPE, PEdim='j', session_
     distortrevPE are single integers, which indicate which of these directories contain the phase
     encoding images, in the same and reverse directions, respectively, as the EPIs.
 
+    NOTE that this should be run *after* the functional scans from the same session have been put
+    into place (say, by running `copy_func`) so that the IntendedFor field of the json can be
+    filled in correctly.
+
     we also make the following other assumptions:
 
     - that this is the BIDS fieldmap case 4 (section 8.9.4 in the specifications pdf): multiple
@@ -181,7 +197,11 @@ def copy_fmap(data_dir, output_dir, distortPE, distortrevPE, PEdim='j', session_
       each volume in each distortion scan and that there are 3 volumes per scan, for a total
       readout time of 3 seconds.
 
-    - that these are inteded for all scans gathered in the same session.
+    - the distortPE scan has phase encoding direction PEdim and distortrevPE has the opposite. In
+      BIDS-speak, this means we assume the distortPE scan has the forward direction (i, j, or k)
+      and distortrevPE has the reverse direction ('i-', 'j-', 'k-')
+
+    - that these are intended for all scans (including SBRefs) gathered in the same session.
 
     - the direction label can be inferred from the filename, which will have DISTORTION_%%, where
       %% are two alphanumeric characters that we'll use for the direction label (note that these
@@ -224,11 +244,16 @@ def copy_fmap(data_dir, output_dir, distortPE, distortrevPE, PEdim='j', session_
             ext = "nii"
         direction = re.search("DISTORTION_([A-Za-z0-9]+)", distort_file).groups()[0]
         shutil.copy(distort_file, os.path.join(subj_dir, base_filename % (direction, ext)))
+        possible_PEdims = ['x', 'y', 'z', 'i', 'j', 'k']
+        if PEdim not in possible_PEdims:
+            raise Exception("Don't know how to handle PEdim %s!" % PEdim)
         phase_dir = {'x': 'i', 'y': 'j', 'z': 'k'}.get(PEdim, PEdim)
         # the reversed distortion scan should have the dash after it.
         if i == 1:
             phase_dir += '-'
-        fmap_dict = {'PhaseEncodingDirection': phase_dir, 'TotalReadoutTime': 3}
+        intended_for = glob.glob(os.path.join(os.path.dirname(subj_dir), 'func', '*.nii'))
+        fmap_dict = {'PhaseEncodingDirection': phase_dir, 'TotalReadoutTime': 3,
+                     'IntendedFor': intended_for}
         with open(os.path.join(subj_dir, base_filename % (direction, "json")), 'w') as f:
             json.dump(fmap_dict, f)
 

--- a/BIDS/prisma_to_BIDS.py
+++ b/BIDS/prisma_to_BIDS.py
@@ -57,14 +57,14 @@ def _construct_base_filename(example_file, output_dir, data_type, run_flag=False
                                               "dir", "ce"]))
     if session_label is None:
         subj_dir = os.path.join(subj_dir, data_type)
-        if os.path.exists(os.path.join(subj_dir, data_type)):
-            raise Exception("subj_dir already exists but you have no session_label set! You need a "
-                            "session_label if subject has multiple sessions")
+        if os.path.exists(os.path.join(subj_dir)):
+            raise IOError("subj_dir already exists but you have no session_label set! You need a "
+                          "session_label if subject has multiple sessions")
     else:
         subj_dir = os.path.join(subj_dir, "ses-%s" % session_label, data_type)
         filename_kw["session"] = "_ses-%s" % session_label
         if os.path.exists(subj_dir):
-            raise Exception("The session_label %s has already been used, choose another!" % session_label)
+            raise IOError("The session_label %s has already been used, choose another!" % session_label)
     if task_label is not None:
         filename_kw['task'] = "_task-%s" % task_label
     if acq_label is not None:
@@ -160,7 +160,7 @@ def copy_func(data_dir, output_dir, epis, sbrefs, task_label, session_label=None
             tr /= 1000
         elif t_units != 'sec':
             raise Exception("Don't know how to handle units %s for TR" % t_units)
-        bold_dict = {"TaskName": task_label, 'RepetitionTime': tr}
+        bold_dict = {"TaskName": task_label, 'RepetitionTime': float(tr)}
         with open(os.path.join(subj_dir, epi_filename % (i+1, 'json')), 'w') as f:
             json.dump(bold_dict, f)
 

--- a/BIDS/prisma_to_BIDS.py
+++ b/BIDS/prisma_to_BIDS.py
@@ -30,7 +30,6 @@ import nibabel as nib
 import warnings
 
 
-
 def _construct_base_filename(example_file, output_dir, data_type, run_flag=False, task_label=None,
                              session_label=None, acq_label=None, rec_label=None, echo_index=None,
                              dir_flag=False, ce_label=None):
@@ -272,18 +271,17 @@ def copy_anat(data_dir, output_dir, anat_nums, modality_label, session_label=Non
             output_path = os.path.join(subj_dir, base_filename % (run_label[i], ext))
         out_code = 0
         try:
-            out_code = subprocess.call(['pydeface', anat_file, output_path])
+            out_code = subprocess.call(['pydeface', '--outfile', output_path, anat_file])
         except OSError:
-            out_code = subprocess.call(['pydeface.py', anat_file, output_path])
-            except OSError:
-                warnings.warn("No pydeface.py! Download and install from https://github.com/poldracklab/pydeface"
-                              " We are simply copying over the anatomical data.")
-                shutil.copy(anat_file, output_path)
-        if out_code==1:
+            warnings.warn("No pydeface (version 2.0 is required)! Download and install from "
+                          "https://github.com/poldracklab/pydeface We are simply copying over the "
+                          "anatomical data.")
+            shutil.copy(anat_file, output_path)
+        if out_code == 1:
             raise IOError("Cannot find anatomical file at %s!" % anat_file)
-        elif out_code==2:
-            warnings.warn("FSL must be installed and FSLDIR environment variable must be defined."
-                          " We are simply copying over the anatomical data.")
+        elif out_code == 2:
+            warnings.warn("pydeface encountered an error (see above). We'll simply copy over the"
+                          " anatomical data.")
             shutil.copy(anat_file, output_path)
 
 

--- a/README.md
+++ b/README.md
@@ -12,5 +12,18 @@ the preprocessing script requires FSL and Freesurfer.
 
 # How to use
 
+## Preprocessing
+
 For an example of how to run, see the [Winawer lab
 wiki](https://wikis.nyu.edu/pages/viewpage.action?pageId=86054639)
+
+## Prisma to BIDS
+
+These functions can be used to transfer data from the default way it
+comes off NYU CBI's prisma scanner to a BIDS-compliant structure. This
+is only a temporary way of handling things, since eventually CBI will
+add BIDS as a possible export option. For an example of how to use
+this,
+see
+[this script](https://github.com/billbrod/spatial-frequency-preferences/blob/master/sfp/transfer_to_BIDS.py) from
+the spatial frequency preferences experiment.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 Matlab and Python tools for MRI analyses
 
 # Requirements
+
 Python requirements are listed in the requirements.txt file,
 additionally [pydeface](https://github.com/poldracklab/pydeface) is
-required to deface anatomical data (in `prisma_to_BIDS.py`), which
-also requires FSL, and the preprocessing script requires FSL and
-Freesurfer.
+required to deface anatomical data (in `prisma_to_BIDS.py`; if either
+pydeface or FSL is unavailable, we will simply copy over the
+anatomical data), which also requires FSL, and the preprocessing
+script requires FSL and Freesurfer.
 
 # How to use
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ version 2.0 is required to deface anatomical data (in
 simply copy over the anatomical data), which also requires FSL, and
 the preprocessing script requires FSL and Freesurfer.
 
+Additionally, if you want to use the `prisma_preproc.py` to preprocess
+BIDS-formatted data, [pybids](https://github.com/INCF/pybids) is
+required (and can be installed from pip).
+
 # How to use
 
 ## Preprocessing

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Matlab and Python tools for MRI analyses
 # Requirements
 
 Python requirements are listed in the requirements.txt file,
-additionally [pydeface](https://github.com/poldracklab/pydeface) is
-required to deface anatomical data (in `prisma_to_BIDS.py`; if either
-pydeface or FSL is unavailable, we will simply copy over the
-anatomical data), which also requires FSL, and the preprocessing
-script requires FSL and Freesurfer.
+additionally [pydeface](https://github.com/poldracklab/pydeface)
+version 2.0 is required to deface anatomical data (in
+`prisma_to_BIDS.py`; if either pydeface or FSL is unavailable, we will
+simply copy over the anatomical data), which also requires FSL, and
+the preprocessing script requires FSL and Freesurfer.
 
 # How to use
 

--- a/preprocessing/prisma_preproc.py
+++ b/preprocessing/prisma_preproc.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import os
 import os.path as op
-import shutil
 from glob import glob
 import numpy as np
 from nipype import Workflow, Node, MapNode, DataSink
@@ -98,7 +97,7 @@ def main(arglist):
     session['plugin_args'] = {}
     if args['plugin_args'] is not None:
         for arg in args['plugin_args'].split(','):
-            if len(arg.split(':'))!=2:
+            if len(arg.split(':')) != 2:
                 raise Exception("Your plugin_args is incorrectly formatted, each should contain one colon!")
             k, v = arg.split(':')
             try:
@@ -121,13 +120,11 @@ def main(arglist):
     preproc_wf.run(session["plugin"], plugin_args=session['plugin_args'])
 
 
-
 def create_preproc_workflow(session):
-    
     """
     Defines simple functional preprocessing workflow, including motion
-    correction, registration to distortion scans, and unwarping. Assumes 
-    recon-all has been performed on T1, and computes but does not apply 
+    correction, registration to distortion scans, and unwarping. Assumes
+    recon-all has been performed on T1, and computes but does not apply
     registration to anatomy.
     """
 
@@ -138,9 +135,9 @@ def create_preproc_workflow(session):
     #---EPI Realignment---
 
     # Realign every TR in each functional run to the sbref image using mcflirt
-    realign = MapNode(fsl.MCFLIRT(ref_file=session['sbref'], 
-                                  save_mats=True, 
-                                  save_plots=True), 
+    realign = MapNode(fsl.MCFLIRT(ref_file=session['sbref'],
+                                  save_mats=True,
+                                  save_plots=True),
                       iterfield=['in_file'], name='realign')
     realign.inputs.in_file = session['epis']
     wf.add_nodes([realign])
@@ -149,11 +146,11 @@ def create_preproc_workflow(session):
     #---Registration to distortion scan---
 
     # Register the sbref scan to the distortion scan with the same PE using flirt
-    reg2dist = Node(fsl.FLIRT(in_file=session['sbref'], 
-                              reference=session['distort_PE'], 
+    reg2dist = Node(fsl.FLIRT(in_file=session['sbref'],
+                              reference=session['distort_PE'],
                               out_file='sbref_reg.nii.gz',
-                              out_matrix_file='sbref2dist.mat', 
-                              dof=6), 
+                              out_matrix_file='sbref2dist.mat',
+                              dof=6),
                     name='reg2distort')
     wf.add_nodes([reg2dist])
 
@@ -162,8 +159,8 @@ def create_preproc_workflow(session):
 
     # Merge the two distortion scans for unwarping
     distort_scans = [session['distort_PE'], session['distort_revPE']]
-    merge_dist = Node(fsl.Merge(in_files=distort_scans, 
-                                dimension='t', 
+    merge_dist = Node(fsl.Merge(in_files=distort_scans,
+                                dimension='t',
                                 merged_file='distortion_merged.nii.gz'),
                       name='merge_distort')
     wf.add_nodes([merge_dist])
@@ -171,7 +168,7 @@ def create_preproc_workflow(session):
     # Run topup to estimate warpfield and create unwarped distortion scans
     PEs = np.repeat([session['PE_dim'], session['PE_dim'] + '-'], 3)
     unwarp_dist = Node(fsl.TOPUP(encoding_direction=list(PEs),
-                                 readout_times=[1, 1, 1, 1, 1, 1], 
+                                 readout_times=[1, 1, 1, 1, 1, 1],
                                  config='b02b0.cnf'),
                        name='unwarp_distort')
     wf.connect(merge_dist, 'merged_file', unwarp_dist, 'in_file')
@@ -179,9 +176,9 @@ def create_preproc_workflow(session):
     # Unwarp sbref image in case it's useful
     unwarp_sbref = Node(fsl.ApplyTOPUP(in_index=[1], method='jac'),
                         name='unwarp_sbref')
-    wf.connect([(reg2dist, unwarp_sbref, 
-                    [('out_file', 'in_files')]),
-                (unwarp_dist, unwarp_sbref, 
+    wf.connect([(reg2dist, unwarp_sbref,
+                 [('out_file', 'in_files')]),
+                (unwarp_dist, unwarp_sbref,
                     [('out_enc_file', 'encoding_file'),
                      ('out_fieldcoef', 'in_topup_fieldcoef'),
                      ('out_movpar', 'in_topup_movpar')])])
@@ -190,15 +187,15 @@ def create_preproc_workflow(session):
     #---Registration to anatomy---
 
     # Create mean unwarped distortion scan
-    mean_unwarped_dist = Node(fsl.MeanImage(dimension='T'), 
+    mean_unwarped_dist = Node(fsl.MeanImage(dimension='T'),
                               name='mean_unwarped_distort')
     wf.connect(unwarp_dist, 'out_corrected', mean_unwarped_dist, 'in_file')
 
     # Register mean unwarped distortion scan to anatomy using bbregister
-    reg2anat = Node(fs.BBRegister(subject_id=session['subj'], 
-                                  contrast_type='t2', 
-                                  init='fsl', 
-                                  out_reg_file='distort2anat_tkreg.dat', 
+    reg2anat = Node(fs.BBRegister(subject_id=session['subj'],
+                                  contrast_type='t2',
+                                  init='fsl',
+                                  out_reg_file='distort2anat_tkreg.dat',
                                   out_fsl_file='distort2anat_flirt.mat'),
                     name='reg2anat')
     wf.connect(mean_unwarped_dist, 'out_file', reg2anat, 'source_file')
@@ -207,38 +204,38 @@ def create_preproc_workflow(session):
     #---Combine and apply transforms to EPIs---
 
     # Split EPI runs into 3D files
-    split_epis = MapNode(fsl.Split(dimension='t'), 
+    split_epis = MapNode(fsl.Split(dimension='t'),
                          iterfield=['in_file'], name='split_epis')
     split_epis.inputs.in_file = session['epis']
     wf.add_nodes([split_epis])
 
     # Combine the rigid transforms to be applied to each EPI volume
     concat_rigids = MapNode(fsl.ConvertXFM(concat_xfm=True),
-                            iterfield=['in_file'], 
+                            iterfield=['in_file'],
                             nested=True,
                             name='concat_rigids')
-    wf.connect([(realign, concat_rigids, 
-                    [('mat_file', 'in_file')]),
-                (reg2dist, concat_rigids, 
+    wf.connect([(realign, concat_rigids,
+                 [('mat_file', 'in_file')]),
+                (reg2dist, concat_rigids,
                     [('out_matrix_file', 'in_file2')])])
 
     # Apply rigid transforms and warpfield to each EPI volume
     correct_epis = MapNode(fsl.ApplyWarp(interp='spline', relwarp=True),
-                           iterfield=['in_file', 'ref_file', 'premat'], 
-                           nested=True, 
+                           iterfield=['in_file', 'ref_file', 'premat'],
+                           nested=True,
                            name='correct_epis')
 
     get_warp = lambda warpfields: warpfields[0]
-    wf.connect([(split_epis, correct_epis, 
+    wf.connect([(split_epis, correct_epis,
                     [('out_files', 'in_file'),
                      ('out_files', 'ref_file')]),
-                (concat_rigids, correct_epis, 
+                (concat_rigids, correct_epis,
                     [('out_file', 'premat')]),
-                (unwarp_dist, correct_epis, 
+                (unwarp_dist, correct_epis,
                     [(('out_warps', get_warp), 'field_file')])])
 
     # Merge processed files back into 4D nifti
-    merge_epis = MapNode(fsl.Merge(dimension='t', 
+    merge_epis = MapNode(fsl.Merge(dimension='t',
                                    merged_file='timeseries_corrected.nii.gz'),
                          iterfield='in_files',
                          name='merge_epis')
@@ -246,8 +243,8 @@ def create_preproc_workflow(session):
 
 
     #---Copy important files to main directory---
-    substitutions = [('_merge_epis%d/timeseries_corrected.nii.gz' %r, 
-                      'timeseries_corrected_run%02d.nii.gz' %(r+1))
+    substitutions = [('_merge_epis%d/timeseries_corrected.nii.gz' % r,
+                      'timeseries_corrected_run%02d.nii.gz' % (r+1))
                      for r in np.arange(len(session['epis']))]
     ds = Node(DataSink(base_directory=os.path.abspath(session['out']),
                        substitutions=substitutions),
@@ -259,7 +256,7 @@ def create_preproc_workflow(session):
     wf.connect(merge_epis, 'merged_file', ds, '@merge_epis')
 
     return wf
-    
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/preprocessing/prisma_preproc.py
+++ b/preprocessing/prisma_preproc.py
@@ -50,6 +50,13 @@ def main(arglist):
                               "('BIDS')? This determines how we look for the various scans. If "
                               "your data is BIDS-structured, then datadir should point to the "
                               "particular session you want to preprocess as well"))
+    parser.add_argument('-plugin_args', default="",
+                        help=("Any additional arguments to pass to nipype's workflow.run as plugin"
+                              "_args. A single entry in the resulting dictionary should be of the"
+                              " format arg:val (e.g., n_procs:2) with multiple args separated by a"
+                              " comma with no spaces (e.g., n_procs:2,memory_gb:5). see nipype's "
+                              "plugin documentation for more details on possible values: "
+                              "http://nipype.readthedocs.io/en/latest/users/plugins.html. "))
     args = vars(parser.parse_args(arglist))
 
     # Session paths and files
@@ -64,10 +71,11 @@ def main(arglist):
         session['distort_revPE'] = glob(session['nii_temp'] %args['distortrevPE'])[0]
     elif args['dir_structure'] == 'bids':
         session['nii_temp'] = op.join(session['data'], '%s', '*-%02d_%s.nii')
+        session['nii_fmap_temp'] = op.join(session['data'], '%s', '*-%s_%s.nii')
         session['epis'] = [glob(session['nii_temp'] % ('func', r, 'bold'))[0] for r in args['epis']]
         session['sbref'] = glob(session['nii_temp'] % ('func', args['sbref'], 'sbref'))[0]
-        session['distort_PE'] = glob(session['nii_temp'] % ('fmap', args['distortPE'], 'epi'))[0]
-        session['distort_revPE'] = glob(session['nii_temp'] % ('fmap', args['distortrevPE'], 'epi'))[0]
+        session['distort_PE'] = glob(session['nii_fmap_temp'] % ('fmap', args['distortPE'], 'epi'))[0]
+        session['distort_revPE'] = glob(session['nii_fmap_temp'] % ('fmap', args['distortrevPE'], 'epi'))[0]
     else:
         raise Exception("Don't know what to do with dir_structure %s!" % args['dir_structure'])
     session['PE_dim'] = args['PEdim']
@@ -84,6 +92,20 @@ def main(arglist):
     if not op.exists(session["working_dir"]):
         os.makedirs(session['working_dir'])
 
+    session['plugin_args'] = {}
+    for arg in args['plugin_args'].split(','):
+        if len(arg.split(':'))!=2:
+            raise Exception("Your plugin_args is incorrectly formatted, each should contain one colon!")
+        k, v = arg.split(':')
+        try:
+            session['plugin_args'][k] = int(v)
+        except ValueError:
+            try:
+                session['plugin_args'][k] = float(v)
+            except ValueError:
+                session['plugin_args'][k] = v
+    session['plugin'] = args['plugin']
+
     # Dump session info to json
     with open(op.join(session['out'], 'session.json'), 'w') as sess_file:
         json.dump(session, sess_file, sort_keys=True, indent=4)
@@ -92,7 +114,7 @@ def main(arglist):
     preproc_wf = create_preproc_workflow(session)
 
     # Execute workflow in parallel
-    preproc_wf.run(args["plugin"])
+    preproc_wf.run(session["plugin"], plugin_args=session['plugin_args'])
 
 
 

--- a/preprocessing/prisma_preproc.py
+++ b/preprocessing/prisma_preproc.py
@@ -87,7 +87,10 @@ def main(arglist):
                 session['subj'] = "sub-" + subj[0]
             else:
                 session['subj'] = subj[0]
-        session['epis'] = layout.get('file', extensions='nii', type='bold')
+        session['epis'] = sorted(layout.get('file', extensions='nii', type='bold'))
+        if args['epis'] is not None:
+            # then we assume that args['epis'] gives an index into these
+            session['epis'] = np.array(session['epis'])[args['epis']]
         session['sbref'] = layout.get('file', extensions='nii', type='sbref')[0]
         distortion_scans = layout.get('file', extensions='nii', type='epi')
         distortion_scans = glob(session['nii_temp'] % ('fmap', 'epi'))

--- a/preprocessing/prisma_preproc.py
+++ b/preprocessing/prisma_preproc.py
@@ -269,7 +269,7 @@ def create_preproc_workflow(session):
 
     #---Copy important files to main directory---
     substitutions = [('_merge_epis%d/timeseries_corrected.nii.gz' % r,
-                      'timeseries_corrected_run%02d.nii.gz' % (r+1))
+                      'timeseries_corrected_run-%02d.nii.gz' % (r+1))
                      for r in np.arange(len(session['epis']))]
     ds = Node(DataSink(base_directory=os.path.abspath(session['out']),
                        substitutions=substitutions),


### PR DESCRIPTION
This pull request would allow the preprocessing script to work with BIDS data, automatically grabbing most relevant information directly from the directory (using pybids). There are a couple of things to consider:

 - I currently don't have pybids as a requirement, because it's not necessary for the prisma data (we wrap that import in a try / except block). Should it just be a requirement?

 - How do we map from BIDS's i / j / k to FSL'sn x / y / z? I just assume i -> x, j-> y, and k -> z.

 - Most arguments (subject, etc) are now optional. Ideally, they'd be required if `-dir_structure` was prisma and non-existent if `-dir_structure` was bids, but I don't know a better way to handle this. They'll be silently ignored if the data is BIDS-structured, and an exception will get thrown (though a little farther down) if they're not specified and the data is prisma-structured

 - I added `plugin_args`, which allows the user to specify arguments to pass to the plugins. I use this to tell MultiProc not to grab all the cpus / memory when on the cluster. But the text must be structured in a very particular way, so it's a little finicky to use. Not sure if there's a better way.

 - `prisma_to_BIDS.py` has been updated but with Flywheel now able to do the conversion directly from the DICOMs, not sure we'll need it. The `json_check` function might still be helpful, as it agglomerates jsons (i.e., if all functional jsons have the same RepetitionTime, the function will remove that key from all of them and put it in a json in the directory above, in a BIDS-compliant way)